### PR TITLE
Configurable prefix ingress

### DIFF
--- a/charts/clearml/Chart.yaml
+++ b/charts/clearml/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clearml
 description: MLOps platform
 type: application
-version: "2.0.1"
+version: "2.1.1"
 appVersion: "1.1.1"
 home: https://clear.ml
 icon: https://raw.githubusercontent.com/allegroai/clearml/master/docs/clearml-logo.svg

--- a/charts/clearml/Chart.yaml
+++ b/charts/clearml/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clearml
 description: MLOps platform
 type: application
-version: "2.1.1"
+version: "2.1.0"
 appVersion: "1.1.1"
 home: https://clear.ml
 icon: https://raw.githubusercontent.com/allegroai/clearml/master/docs/clearml-logo.svg

--- a/charts/clearml/README.md
+++ b/charts/clearml/README.md
@@ -1,6 +1,6 @@
 # ClearML Ecosystem for Kubernetes
 
-![Version: 2.0.1](https://img.shields.io/badge/Version-2.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.1](https://img.shields.io/badge/AppVersion-1.1.1-informational?style=flat-square)
+![Version: 2.1.1](https://img.shields.io/badge/Version-2.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.1](https://img.shields.io/badge/AppVersion-1.1.1-informational?style=flat-square)
 
 MLOps platform
 
@@ -252,6 +252,9 @@ For detailed instructions, see the [Optional Configuration](https://github.com/a
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `false` |  |
 | ingress.host | string | `""` |  |
+| ingress.hostPrefixApi | string | `"api."` |  |
+| ingress.hostPrefixApp | string | `"app."` |  |
+| ingress.hostPrefixFiles | string | `"files."` |  |
 | ingress.name | string | `"clearml-server-ingress"` |  |
 | ingress.tls.secretName | string | `""` |  |
 | mongodb.architecture | string | `"standalone"` |  |

--- a/charts/clearml/README.md
+++ b/charts/clearml/README.md
@@ -1,6 +1,6 @@
 # ClearML Ecosystem for Kubernetes
 
-![Version: 2.1.1](https://img.shields.io/badge/Version-2.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.1](https://img.shields.io/badge/AppVersion-1.1.1-informational?style=flat-square)
+![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.1](https://img.shields.io/badge/AppVersion-1.1.1-informational?style=flat-square)
 
 MLOps platform
 

--- a/charts/clearml/templates/ingress.yaml
+++ b/charts/clearml/templates/ingress.yaml
@@ -18,30 +18,33 @@ spec:
   {{- if .Values.ingress.tls.secretName }}
   tls:
     - hosts:
-        - "app.{{ .Values.ingress.host }}"
-        - "files.{{ .Values.ingress.host }}"
-        - "api.{{ .Values.ingress.host }}"
+        - "{{ .Values.ingress.hostPrefixAp }}{{ .Values.ingress.host }}"
+        - "{{ .Values.ingress.hostPrefixFiles }}{{ .Values.ingress.host }}"
+        - "{{ .Values.ingress.hostPrefixApi }}{{ .Values.ingress.host }}"
       secretName: {{ .Values.ingress.tls.secretName }}
   {{- end }}
   rules:
-    - host: "app.{{ .Values.ingress.host }}"
+    - host: "{{ .Values.ingress.hostPrefixApp }}{{ .Values.ingress.host }}"
       http:
         paths:
-          - path: "/*"
+          - path: "/"
+            pathType: Prefix
             backend:
               serviceName: {{ include "clearml.fullname" . }}-webserver
               servicePort: {{ .Values.webserver.service.port }}
-    - host: "api.{{ .Values.ingress.host }}"
+    - host: "{{ .Values.ingress.hostPrefixApi }}{{ .Values.ingress.host }}"
       http:
         paths:
-          - path: "/*"
+          - path: "/"
+            pathType: Prefix
             backend:
               serviceName: {{ include "clearml.fullname" . }}-apiserver
               servicePort: {{ .Values.apiserver.service.port }}
-    - host: "files.{{ .Values.ingress.host }}"
+    - host: "{{ .Values.ingress.hostPrefixFiles }}{{ .Values.ingress.host }}"
       http:
         paths:
-          - path: "/*"
+          - path: "/"
+            pathType: Prefix
             backend:
               serviceName: {{ include "clearml.fullname" . }}-fileserver
               servicePort: {{ .Values.fileserver.service.port }}

--- a/charts/clearml/values.yaml
+++ b/charts/clearml/values.yaml
@@ -5,6 +5,9 @@ ingress:
   name: clearml-server-ingress
   annotations: {}
   host: ""
+  hostPrefixApp: "app."
+  hostPrefixApi: "api."
+  hostPrefixFiles: "files."
   tls:
     secretName: ""
 


### PR DESCRIPTION
Sometimes having ingress that forces a 4th level domain (e.g. `api.clearml.mydomain.com`) may not be the best solution, especially when dealing with certificates.

With this PR it will be possible to override the prefix like `api-clearml.mydomain.com` (not possible atm).