### PR TITLE
Use Recreate as strategy

### DIFF
--- a/charts/clearml/Chart.yaml
+++ b/charts/clearml/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clearml
 description: MLOps platform
 type: application
-version: "2.1.1"
+version: "2.1.2"
 appVersion: "1.1.1"
 home: https://clear.ml
 icon: https://raw.githubusercontent.com/allegroai/clearml/master/docs/clearml-logo.svg

--- a/charts/clearml/Chart.yaml
+++ b/charts/clearml/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clearml
 description: MLOps platform
 type: application
-version: "2.1.2"
+version: "2.2.0"
 appVersion: "1.1.1"
 home: https://clear.ml
 icon: https://raw.githubusercontent.com/allegroai/clearml/master/docs/clearml-logo.svg

--- a/charts/clearml/README.md
+++ b/charts/clearml/README.md
@@ -1,6 +1,6 @@
 # ClearML Ecosystem for Kubernetes
 
-![Version: 2.1.1](https://img.shields.io/badge/Version-2.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.1](https://img.shields.io/badge/AppVersion-1.1.1-informational?style=flat-square)
+![Version: 2.1.2](https://img.shields.io/badge/Version-2.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.1](https://img.shields.io/badge/AppVersion-1.1.1-informational?style=flat-square)
 
 MLOps platform
 

--- a/charts/clearml/README.md
+++ b/charts/clearml/README.md
@@ -131,6 +131,7 @@ For detailed instructions, see the [Optional Configuration](https://github.com/a
 | agentGroups.agent-group-cpu.queues | string | `"default"` |  |
 | agentGroups.agent-group-cpu.replicaCount | int | `1` |  |
 | agentGroups.agent-group-cpu.tolerations | list | `[]` |  |
+| agentGroups.agent-group-cpu.updateStrategy | string | `"Recreate"` |  |
 | agentGroups.agent-group-gpu.affinity | object | `{}` |  |
 | agentGroups.agent-group-gpu.agentVersion | string | `""` |  |
 | agentGroups.agent-group-gpu.awsAccessKeyId | string | `nil` |  |
@@ -153,6 +154,7 @@ For detailed instructions, see the [Optional Configuration](https://github.com/a
 | agentGroups.agent-group-gpu.queues | string | `"default"` |  |
 | agentGroups.agent-group-gpu.replicaCount | int | `0` |  |
 | agentGroups.agent-group-gpu.tolerations | list | `[]` |  |
+| agentGroups.agent-group-gpu.updateStrategy | string | `"Recreate"` |  |
 | agentservices.affinity | object | `{}` |  |
 | agentservices.agentVersion | string | `""` |  |
 | agentservices.awsAccessKeyId | string | `nil` |  |

--- a/charts/clearml/README.md
+++ b/charts/clearml/README.md
@@ -1,6 +1,6 @@
 # ClearML Ecosystem for Kubernetes
 
-![Version: 2.1.2](https://img.shields.io/badge/Version-2.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.1](https://img.shields.io/badge/AppVersion-1.1.1-informational?style=flat-square)
+![Version: 2.2.0](https://img.shields.io/badge/Version-2.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.1](https://img.shields.io/badge/AppVersion-1.1.1-informational?style=flat-square)
 
 MLOps platform
 

--- a/charts/clearml/templates/deployment-agent.yaml
+++ b/charts/clearml/templates/deployment-agent.yaml
@@ -20,6 +20,8 @@ spec:
       {{- end }}
       labels:
         {{- include "clearml.selectorLabelsAgent" $ | nindent 8 }}
+    strategy:
+      type: Recreate
     spec:
       volumes:
         {{ if .clearmlConfig }}

--- a/charts/clearml/templates/deployment-agent.yaml
+++ b/charts/clearml/templates/deployment-agent.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   replicas: {{ .replicaCount }}
   strategy:
-    type: Recreate
+    type: {{ .updateStrategy }}
   selector:
     matchLabels:
       {{- include "clearml.selectorLabelsAgent" $ | nindent 6 }}

--- a/charts/clearml/templates/deployment-agent.yaml
+++ b/charts/clearml/templates/deployment-agent.yaml
@@ -9,6 +9,8 @@ metadata:
     {{- include "clearml.labels" $ | nindent 4 }}
 spec:
   replicas: {{ .replicaCount }}
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "clearml.selectorLabelsAgent" $ | nindent 6 }}
@@ -20,8 +22,6 @@ spec:
       {{- end }}
       labels:
         {{- include "clearml.selectorLabelsAgent" $ | nindent 8 }}
-    strategy:
-      type: Recreate
     spec:
       volumes:
         {{ if .clearmlConfig }}

--- a/charts/clearml/values.yaml
+++ b/charts/clearml/values.yaml
@@ -186,6 +186,7 @@ agentGroups:
   agent-group-cpu:
     name: agent-group-cpu
     replicaCount: 1
+    updateStrategy: Recreate
     nvidiaGpusPerAgent: 0
     agentVersion: ""  # if set, it *MUST* include comparison operator (e.g. ">=0.16.1")
     queues: "default"  # multiple queues can be specified separated by a space (e.g. "important_jobs default")
@@ -218,6 +219,7 @@ agentGroups:
   agent-group-gpu:
     name: agent-group-gpu
     replicaCount: 0
+    updateStrategy: Recreate
     nvidiaGpusPerAgent: 1
     agentVersion: ""  # if set, it *MUST* include comparison operator (e.g. ">=0.16.1")
     queues: "default"  # multiple queues can be specified separated by a space (e.g. "important_jobs default")


### PR DESCRIPTION
When agents need to be recreated we should use Recreate strategy due to resources.

For example:

if every GPU is taken, update rollout will never complete because there will ne no available GPU. So it's better to delete the before deploying new ones