### PR TITLE
External services

### DIFF
--- a/charts/clearml/Chart.yaml
+++ b/charts/clearml/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clearml
 description: MLOps platform
 type: application
-version: "3.0.4"
+version: "3.1.0"
 appVersion: "1.1.1"
 home: https://clear.ml
 icon: https://raw.githubusercontent.com/allegroai/clearml/master/docs/clearml-logo.svg

--- a/charts/clearml/README.md
+++ b/charts/clearml/README.md
@@ -1,6 +1,6 @@
 # ClearML Ecosystem for Kubernetes
 
-![Version: 3.0.4](https://img.shields.io/badge/Version-3.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.1](https://img.shields.io/badge/AppVersion-1.1.1-informational?style=flat-square)
+![Version: 3.1.0](https://img.shields.io/badge/Version-3.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.1](https://img.shields.io/badge/AppVersion-1.1.1-informational?style=flat-square)
 
 MLOps platform
 
@@ -238,6 +238,12 @@ For detailed instructions, see the [Optional Configuration](https://github.com/a
 | elasticsearch.roles.remote_cluster_client | string | `"true"` |  |
 | elasticsearch.volumeClaimTemplate.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | elasticsearch.volumeClaimTemplate.resources.requests.storage | string | `"50Gi"` |  |
+| externalServices.elasticsearchHost | string | `""` | Existing ElasticSearch Hostname to use if elasticsearch.enabled is false |
+| externalServices.elasticsearchPort | int | `9200` | Existing ElasticSearch Port to use if elasticsearch.enabled is false |
+| externalServices.mongodbHost | string | `""` | Existing MongoDB Hostname to use if elasticsearch.enabled is false |
+| externalServices.mongodbPort | int | `27017` | Existing MongoDB Port to use if elasticsearch.enabled is false |
+| externalServices.redisHost | string | `""` | Existing Redis Hostname to use if elasticsearch.enabled is false |
+| externalServices.redisPort | int | `6379` | Existing Redis Port to use if elasticsearch.enabled is false |
 | fileserver.affinity | object | `{}` |  |
 | fileserver.extraEnvs | list | `[]` |  |
 | fileserver.image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/clearml/templates/deployment-apiserver.yaml
+++ b/charts/clearml/templates/deployment-apiserver.yaml
@@ -28,17 +28,41 @@ spec:
               protocol: TCP
           env:
           - name: CLEARML_ELASTIC_SERVICE_HOST
+          {{- if .Values.elasticsearch.enabled }}
             value: "{{ .Values.elasticsearch.clusterName }}-master"
+          {{- else }}
+            value: "{{ .Values.externalServices.elasticsearchHost }}"
+          {{- end }}
           - name: CLEARML_ELASTIC_SERVICE_PORT
+          {{- if .Values.elasticsearch.enabled }}
             value: "{{ .Values.elasticsearch.httpPort }}"
+          {{- else }}
+            value: "{{ .Values.externalServices.elasticsearchPort }}"
+          {{- end }}
           - name: CLEARML_MONGODB_SERVICE_HOST
+          {{- if .Values.mongodb.enabled }}
             value: "{{ tpl .Values.mongodb.service.name . }}"
+          {{- else }}
+            value: "{{ .Values.externalServices.mongodbHost }}"
+          {{- end }}
           - name: CLEARML_MONGODB_SERVICE_PORT
+          {{- if .Values.mongodb.enabled }}
             value: "{{ .Values.mongodb.service.port }}"
+          {{- else }}
+            value: "{{ .Values.externalServices.mongodbPort }}"
+          {{- end }}
           - name: CLEARML_REDIS_SERVICE_HOST
+          {{- if .Values.redis.enabled }}
             value: "{{ tpl .Values.redis.master.name . }}"
+          {{- else }}
+            value: "{{ .Values.externalServices.redisHost }}"
+          {{- end }}
           - name: CLEARML_REDIS_SERVICE_PORT
+          {{- if .Values.redis.enabled }}
             value: "{{ .Values.redis.master.port }}"
+          {{- else }}
+            value: "{{ .Values.externalServices.redisPort }}"
+          {{- end }}
           - name: CLEARML__APISERVER__PRE_POPULATE__ENABLED
             value: "{{ .Values.apiserver.prepopulateEnabled }}"
           - name: CLEARML__APISERVER__PRE_POPULATE__ZIP_FILES

--- a/charts/clearml/values.yaml
+++ b/charts/clearml/values.yaml
@@ -259,6 +259,20 @@ agentGroups:
 
     affinity: {}
 
+externalServices:
+  # -- Existing ElasticSearch Hostname to use if elasticsearch.enabled is false
+  elasticsearchHost: ""
+  # -- Existing ElasticSearch Port to use if elasticsearch.enabled is false
+  elasticsearchPort: 9200
+  # -- Existing MongoDB Hostname to use if elasticsearch.enabled is false
+  mongodbHost: ""
+  # -- Existing MongoDB Port to use if elasticsearch.enabled is false
+  mongodbPort: 27017
+  # -- Existing Redis Hostname to use if elasticsearch.enabled is false
+  redisHost: ""
+  # -- Existing Redis Port to use if elasticsearch.enabled is false
+  redisPort: 6379
+
 redis:  # configuration from https://github.com/bitnami/charts/blob/master/bitnami/redis/values.yaml
   enabled: true
   usePassword: false


### PR DESCRIPTION
With the implementation it's possible to use external Redis/Elastic/MongoDB avoiding to install dependency charts.
In case dependency chart is disabled, it's possible to declare endpoints where api server will connect.

It's related #35 .