### PR TITLE
remove k8s 1.22 from ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,11 +19,9 @@ jobs:
     needs:
       - lint-docs
     strategy:
-      max-parallel: 1
       matrix:
         k8s:
           - v1.21.2
-          - v1.22.4
           - v1.23.0
     steps:
       - name: Checkout


### PR DESCRIPTION
It looks 1.22 k8s image from kind has a very low ulimit preventing elastic search from installing, removing it waiting for a fix.