### PR TITLE
add k8s 1.22.1 to ci procedure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,7 @@ jobs:
       matrix:
         k8s:
           - v1.21.2
+          - v1.22.1
           - v1.23.0
     steps:
       - name: Checkout


### PR DESCRIPTION
After some tests I found 1.22.1 doesn't have ulimit issue so I can include it into the ci process