### PR TITLE
update ingress templates to accept per-service annotation overrides

### DIFF
--- a/charts/clearml/Chart.yaml
+++ b/charts/clearml/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clearml
 description: MLOps platform
 type: application
-version: "3.3.0"
+version: "3.3.1"
 appVersion: "1.1.1"
 home: https://clear.ml
 icon: https://raw.githubusercontent.com/allegroai/clearml/master/docs/clearml-logo.svg

--- a/charts/clearml/README.md
+++ b/charts/clearml/README.md
@@ -1,6 +1,6 @@
 # ClearML Ecosystem for Kubernetes
 
-![Version: 3.3.0](https://img.shields.io/badge/Version-3.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.1](https://img.shields.io/badge/AppVersion-1.1.1-informational?style=flat-square)
+![Version: 3.3.1](https://img.shields.io/badge/Version-3.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.1](https://img.shields.io/badge/AppVersion-1.1.1-informational?style=flat-square)
 
 MLOps platform
 
@@ -268,11 +268,14 @@ For detailed instructions, see the [Optional Configuration](https://github.com/a
 | fileserver.storage.data.size | string | `"50Gi"` |  |
 | fileserver.tolerations | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
+| ingress.api.annotations | object | `{}` |  |
 | ingress.api.hostName | string | `"api.clearml.127-0-0-1.nip.io"` |  |
 | ingress.api.tlsSecretName | string | `""` |  |
+| ingress.app.annotations | object | `{}` |  |
 | ingress.app.hostName | string | `"app.clearml.127-0-0-1.nip.io"` |  |
 | ingress.app.tlsSecretName | string | `""` |  |
 | ingress.enabled | bool | `false` |  |
+| ingress.files.annotations | object | `{}` |  |
 | ingress.files.hostName | string | `"files.clearml.127-0-0-1.nip.io"` |  |
 | ingress.files.tlsSecretName | string | `""` |  |
 | ingress.name | string | `"clearml-server-ingress"` |  |

--- a/charts/clearml/templates/ingress-api.yaml
+++ b/charts/clearml/templates/ingress-api.yaml
@@ -11,10 +11,13 @@ metadata:
   name: {{ include "clearml.fullname" . }}-api
   labels:
     {{- include "clearml.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
+  {{- $annotations := .Values.ingress.annotations }}
+  {{- if .Values.ingress.api.annotations }}
+  {{- $annotations = mergeOverwrite $annotations .Values.ingress.api.annotations }}
   {{- end }}
+  annotations:
+    {{- toYaml $annotations | nindent 4 }}
+
 spec:
   {{- if .Values.ingress.api.tlsSecretName }}
   tls:

--- a/charts/clearml/templates/ingress-app.yaml
+++ b/charts/clearml/templates/ingress-app.yaml
@@ -11,10 +11,12 @@ metadata:
   name: {{ include "clearml.fullname" . }}-app
   labels:
     {{- include "clearml.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
+  {{- $annotations := .Values.ingress.annotations }}
+  {{- if .Values.ingress.app.annotations }}
+  {{- $annotations = mergeOverwrite $annotations .Values.ingress.app.annotations }}
   {{- end }}
+  annotations:
+    {{- toYaml $annotations | nindent 4 }}
 spec:
   {{- if .Values.ingress.app.tlsSecretName }}
   tls:

--- a/charts/clearml/templates/ingress-files.yaml
+++ b/charts/clearml/templates/ingress-files.yaml
@@ -11,10 +11,12 @@ metadata:
   name: {{ include "clearml.fullname" . }}-files
   labels:
     {{- include "clearml.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
+  {{- $annotations := .Values.ingress.annotations }}
+  {{- if .Values.ingress.files.annotations }}
+  {{- $annotations = mergeOverwrite $annotations .Values.ingress.files.annotations }}
   {{- end }}
+  annotations:
+    {{- toYaml $annotations | nindent 4 }}
 spec:
   {{- if .Values.ingress.files.tlsSecretName }}
   tls:

--- a/charts/clearml/values.yaml
+++ b/charts/clearml/values.yaml
@@ -7,12 +7,15 @@ ingress:
   app:
     hostName: "app.clearml.127-0-0-1.nip.io"
     tlsSecretName: ""
+    annotations: {}
   api:
     hostName: "api.clearml.127-0-0-1.nip.io"
     tlsSecretName: ""
+    annotations: {}
   files:
     hostName: "files.clearml.127-0-0-1.nip.io"
     tlsSecretName: ""
+    annotations: {}
 
 secret:
   # -- Set for http_session field


### PR DESCRIPTION
If you want to use [cert-manager](https://cert-manager.io/docs/) and [external-dns](https://github.com/kubernetes-sigs/external-dns) annotations you need per-service ingress annotations not shared ones. This PR allows optional overriding of the shared one.

