### PR TITLE
Allowing auth secrets to be optional #2

### DIFF
--- a/charts/clearml-agent/Chart.yaml
+++ b/charts/clearml-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clearml-agent
 description: MLOps platform
 type: application
-version: "1.2.3"
+version: "1.3.0"
 appVersion: "1.24"
 kubeVersion: ">= 1.19.0-0 < 1.25.0-0"
 home: https://clear.ml

--- a/charts/clearml-agent/README.md
+++ b/charts/clearml-agent/README.md
@@ -44,10 +44,12 @@ Kubernetes: `>= 1.19.0-0 < 1.25.0-0`
 | agentk8sglue.replicaCount | int | `1` | Glue Agent number of pods |
 | agentk8sglue.serviceAccountName | string | `"default"` | serviceAccountName for pods spawned to consume ClearML Task |
 | agentk8sglue.webServerUrlReference | string | `"https://app.clear.ml"` | Reference to Web server url |
-| clearml | object | `{"agentk8sglueKey":"ACCESSKEY","agentk8sglueSecret":"SECRETKEY","clearmlConfig":"sdk {\n}"}` | ClearMl generic configurations |
+| clearml | object | `{"agentk8sglueKey":"ACCESSKEY","agentk8sglueSecret":"SECRETKEY","clearmlConfig":"sdk {\n}","existingAgentk8sglueSecret":"","existingClearmlConfigSecret":""}` | ClearMl generic configurations |
 | clearml.agentk8sglueKey | string | `"ACCESSKEY"` | Agent k8s Glue basic auth key |
 | clearml.agentk8sglueSecret | string | `"SECRETKEY"` | Agent k8s Glue basic auth secret |
 | clearml.clearmlConfig | string | `"sdk {\n}"` | ClearML configuration file |
+| clearml.existingAgentk8sglueSecret | string | `""` | If this is set, chart will not generate a secret but will use what is defined here |
+| clearml.existingClearmlConfigSecret | string | `""` | If this is set, chart will not generate a secret but will use what is defined here |
 | imageCredentials | object | `{"email":"someone@host.com","enabled":false,"existingSecret":"","password":"pwd","registry":"docker.io","username":"someone"}` | Private image registry configuration |
 | imageCredentials.email | string | `"someone@host.com"` | Email |
 | imageCredentials.enabled | bool | `false` | Use private authentication mode |

--- a/charts/clearml-agent/README.md
+++ b/charts/clearml-agent/README.md
@@ -1,6 +1,6 @@
 # clearml-agent
 
-![Version: 1.2.3](https://img.shields.io/badge/Version-1.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.24](https://img.shields.io/badge/AppVersion-1.24-informational?style=flat-square)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.24](https://img.shields.io/badge/AppVersion-1.24-informational?style=flat-square)
 
 MLOps platform
 

--- a/charts/clearml-agent/templates/agentk8sglue-configmap.yaml
+++ b/charts/clearml-agent/templates/agentk8sglue-configmap.yaml
@@ -43,12 +43,20 @@ data:
         - name: CLEARML_API_ACCESS_KEY
           valueFrom:
             secretKeyRef:
-              name: {{ include "agentk8sglue.referenceName" . }}-clearml-agent-conf
+              {{- if .Values.clearml.existingAgentk8sglueSecret }}
+              name: {{ .Values.clearml.existingAgentk8sglueSecret }}
+              {{- else }}
+              name: {{ include "agentk8sglue.referenceName" . }}-clearml-agent-k8sglue
+              {{- end }}
               key: agentk8sglue_key
         - name: CLEARML_API_SECRET_KEY
           valueFrom:
             secretKeyRef:
-              name: {{ include "agentk8sglue.referenceName" . }}-clearml-agent-conf
+              {{- if .Values.clearml.existingAgentk8sglueSecret }}
+              name: {{ .Values.clearml.existingAgentk8sglueSecret }}
+              {{- else }}
+              name: {{ include "agentk8sglue.referenceName" . }}-clearml-agent-k8sglue
+              {{- end }}
               key: agentk8sglue_secret
         {{- if .Values.agentk8sglue.podTemplate.env }}
         {{ toYaml .Values.agentk8sglue.podTemplate.env | nindent 8 }}

--- a/charts/clearml-agent/templates/agentk8sglue-deployment.yaml
+++ b/charts/clearml-agent/templates/agentk8sglue-deployment.yaml
@@ -52,7 +52,7 @@ spec:
         volumeMounts:
           - name: {{ include "agentk8sglue.referenceName" . }}-k8sagent-pod-template
             mountPath: /root/template
-          {{ if .Values.clearml.clearmlConfig }}
+          {{- if or .Values.clearml.clearmlConfig .Values.clearml.existingClearmlConfigSecret }}
           - name: k8sagent-clearml-conf-volume
             mountPath: /root/clearml.conf
             subPath: clearml.conf
@@ -76,12 +76,20 @@ spec:
           - name: CLEARML_API_ACCESS_KEY
             valueFrom:
               secretKeyRef:
-                name: {{ include "agentk8sglue.referenceName" . }}-clearml-agent-conf
+                {{- if .Values.clearml.existingAgentk8sglueSecret }}
+                name: {{ .Values.clearml.existingAgentk8sglueSecret }}
+                {{- else }}
+                name: {{ include "agentk8sglue.referenceName" . }}-clearml-agent-k8sglue
+                {{- end }}
                 key: agentk8sglue_key
           - name: CLEARML_API_SECRET_KEY
             valueFrom:
               secretKeyRef:
-                name: {{ include "agentk8sglue.referenceName" . }}-clearml-agent-conf
+                {{- if .Values.clearml.existingAgentk8sglueSecret }}
+                name: {{ .Values.clearml.existingAgentk8sglueSecret }}
+                {{- else }}
+                name: {{ include "agentk8sglue.referenceName" . }}-clearml-agent-k8sglue
+                {{- end }}
                 key: agentk8sglue_secret
           - name: CLEARML_WORKER_ID
             value: "{{.Values.agentk8sglue.id}}"
@@ -98,10 +106,14 @@ spec:
         - name: {{ include "agentk8sglue.referenceName" . }}-k8sagent-pod-template
           configMap: 
             name: {{ include "agentk8sglue.referenceName" . }}-k8sagent-pod-template
-        {{ if .Values.clearml.clearmlConfig }}
+        {{- if or .Values.clearml.clearmlConfig .Values.clearml.existingClearmlConfigSecret }}
         - name: k8sagent-clearml-conf-volume
           secret:
+            {{- if .Values.clearml.existingClearmlConfigSecret }}
+            secretName: {{ .Values.clearml.existingClearmlConfigSecret }}
+            {{- else }}
             secretName: {{ include "agentk8sglue.referenceName" . }}-clearml-agent-conf
+            {{- end }}
             items:
             - key: clearml.conf
               path: clearml.conf

--- a/charts/clearml-agent/templates/clearml-secrets.yaml
+++ b/charts/clearml-agent/templates/clearml-secrets.yaml
@@ -1,12 +1,22 @@
+{{- if not .Values.clearml.existingAgentk8sglueSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "agentk8sglue.referenceName" . }}-clearml-agent-k8sglue
+data:
+  agentk8sglue_key: {{ .Values.clearml.agentk8sglueKey | b64enc }}
+  agentk8sglue_secret: {{ .Values.clearml.agentk8sglueSecret | b64enc }}
+{{- end }}
+---
+{{- if not .Values.clearml.existingClearmlConfigSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "agentk8sglue.referenceName" . }}-clearml-agent-conf
 data:
-  agentk8sglue_key: {{ .Values.clearml.agentk8sglueKey | b64enc }}
-  agentk8sglue_secret: {{ .Values.clearml.agentk8sglueSecret | b64enc }}
   clearml.conf: {{ .Values.clearml.clearmlConfig | b64enc }}
 ---
+{{- end }}
 {{- if .Values.imageCredentials.enabled }}
 {{- if not .Values.imageCredentials.existingSecret }}
 apiVersion: v1

--- a/charts/clearml-agent/values.yaml
+++ b/charts/clearml-agent/values.yaml
@@ -15,10 +15,15 @@ imageCredentials:
 
 # -- ClearMl generic configurations
 clearml:
+  # -- If this is set, chart will not generate a secret but will use what is defined here
+  existingAgentk8sglueSecret: ""
   # -- Agent k8s Glue basic auth key
   agentk8sglueKey: "ACCESSKEY"
   # -- Agent k8s Glue basic auth secret
   agentk8sglueSecret: "SECRETKEY"
+
+  # -- If this is set, chart will not generate a secret but will use what is defined here
+  existingClearmlConfigSecret: ""
   # -- ClearML configuration file
   clearmlConfig: |-
     sdk {

--- a/charts/clearml/Chart.yaml
+++ b/charts/clearml/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clearml
 description: MLOps platform
 type: application
-version: "4.1.3"
+version: "4.2.0"
 appVersion: "1.6.0"
 home: https://clear.ml
 icon: https://raw.githubusercontent.com/allegroai/clearml/master/docs/clearml-logo.svg

--- a/charts/clearml/README.md
+++ b/charts/clearml/README.md
@@ -1,6 +1,6 @@
 # ClearML Ecosystem for Kubernetes
 
-![Version: 4.1.3](https://img.shields.io/badge/Version-4.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.0](https://img.shields.io/badge/AppVersion-1.6.0-informational?style=flat-square)
+![Version: 4.2.0](https://img.shields.io/badge/Version-4.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.0](https://img.shields.io/badge/AppVersion-1.6.0-informational?style=flat-square)
 
 MLOps platform
 

--- a/charts/clearml/README.md
+++ b/charts/clearml/README.md
@@ -256,6 +256,7 @@ For detailed instructions, see the [Optional Configuration](https://github.com/a
 | secret.credentials.apiserver.secretKey | string | `"BxapIRo9ZINi8x25CRxz8Wdmr2pQjzuWVB4PNASZqCtTyWgWVQ"` | Set for apiserver_secret field |
 | secret.credentials.tests.accessKey | string | `"ENP39EQM4SLACGD5FXB7"` | Set for tests_user_key field |
 | secret.credentials.tests.secretKey | string | `"lPcm0imbcBZ8mwgO7tpadutiS3gnJD05x9j7afwXPS35IKbpiQ"` | Set for tests_user_secret field |
+| secret.existingSecret | string | `""` | If this is set, chart will not generate a secret but will use what is defined here |
 | secret.httpSession | string | `"9Tw20RbhJ1bLBiHEOWXvhplKGUbTgLzAtwFN2oLQvWwS0uRpD5"` | Set for http_session field |
 | webserver.additionalConfigs | object | `{}` |  |
 | webserver.affinity | object | `{}` |  |

--- a/charts/clearml/templates/deployment-apiserver.yaml
+++ b/charts/clearml/templates/deployment-apiserver.yaml
@@ -87,32 +87,32 @@ spec:
           - name: CLEARML__SECURE__HTTP__SESSION_SECRET__APISERVER
             valueFrom:
               secretKeyRef:
-                name: clearml-conf
+                name: {{ default "clearml-conf" .Values.secret.existingSecret }}
                 key: http_session
           - name: CLEARML__SECURE__AUTH__TOKEN_SECRET
             valueFrom:
               secretKeyRef:
-                name: clearml-conf
+                name: {{ default "clearml-conf" .Values.secret.existingSecret }}
                 key: auth_token
           - name: CLEARML__SECURE__CREDENTIALS__APISERVER__USER_KEY
             valueFrom:
               secretKeyRef:
-                name: clearml-conf
+                name: {{ default "clearml-conf" .Values.secret.existingSecret }}
                 key: apiserver_key
           - name: CLEARML__SECURE__CREDENTIALS__APISERVER__USER_SECRET
             valueFrom:
               secretKeyRef:
-                name: clearml-conf
+                name: {{ default "clearml-conf" .Values.secret.existingSecret }}
                 key: apiserver_secret
           - name: CLEARML__SECURE__CREDENTIALS__TESTS__USER_KEY
             valueFrom:
               secretKeyRef:
-                name: clearml-conf
+                name: {{ default "clearml-conf" .Values.secret.existingSecret }}
                 key: tests_user_key
           - name: CLEARML__SECURE__CREDENTIALS__TESTS__USER_SECRET
             valueFrom:
               secretKeyRef:
-                name: clearml-conf
+                name: {{ default "clearml-conf" .Values.secret.existingSecret }}
                 key: tests_user_secret
          {{- if .Values.apiserver.extraEnvs }}
          {{ toYaml .Values.apiserver.extraEnvs | nindent 10 }}

--- a/charts/clearml/templates/secrets.yaml
+++ b/charts/clearml/templates/secrets.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.secret.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,3 +10,4 @@ stringData:
   auth_token: {{ .Values.secret.authToken }}
   tests_user_key: {{ .Values.secret.credentials.tests.accessKey }}
   tests_user_secret: {{ .Values.secret.credentials.tests.secretKey }}
+{{- end }}

--- a/charts/clearml/values.yaml
+++ b/charts/clearml/values.yaml
@@ -39,6 +39,9 @@ ingress:
     path: "/"
 
 secret:
+  # -- If this is set, chart will not generate a secret but will use what is defined here
+  existingSecret: ""
+
   # -- Set for http_session field
   httpSession: "9Tw20RbhJ1bLBiHEOWXvhplKGUbTgLzAtwFN2oLQvWwS0uRpD5"
   # -- Set for auth_token field


### PR DESCRIPTION
* Add value secret.existingSecret for clearml chart.

* Add value clearml.existingAgentk8sglueSecret for clearml-agent chart.

* Add value clearml.existingClearmlConfigSecret for clearml-agent chart.

* Split Secret clearml-agent-conf in clearml-agent chart into two
  Secrets: clearml-agent-conf (agent.conf file) and clearml-agent-k8sglue
  (environment variables).