### PR TITLE
Fixed missing brackets for k8 secret (docker config)

### DIFF
--- a/charts/clearml-agent/templates/agentk8sglue-deployment.yaml
+++ b/charts/clearml-agent/templates/agentk8sglue-deployment.yaml
@@ -19,7 +19,7 @@ spec:
       {{- if .Values.imageCredentials.enabled }}
       imagePullSecrets:
       {{- if .Values.imageCredentials.existingSecret }}
-      - name: .Values.imageCredentials.existingSecret
+      - name: "{{.Values.imageCredentials.existingSecret}}"
       {{- else }}
       - name: {{ include "agentk8sglue.referenceName" . }}-clearml-agent-registry-key
       {{- end }}


### PR DESCRIPTION
Missing helm brackets on the `imagePullSecret`