### PR TITLE
Override pathType in webserver

### DIFF
--- a/charts/clearml/templates/webserver-ingress.yaml
+++ b/charts/clearml/templates/webserver-ingress.yaml
@@ -34,7 +34,7 @@ spec:
       paths:
       - path: {{ .Values.webserver.ingress.path }}
   {{ if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
-        pathType: Prefix
+        pathType: {{ .Values.webserver.ingress.pathType | default "Prefix" }}
         backend:
           service:
             name: {{ include "webserver.referenceName" . }}

--- a/charts/clearml/values.yaml
+++ b/charts/clearml/values.yaml
@@ -298,6 +298,8 @@ webserver:
     annotations: {}
     # -- Ingress root path url
     path: "/"
+    # -- Ingress pathType override default
+    pathType: ""
   # -- Web Server extra envrinoment variables
   extraEnvs: []
   # -- specific annotation for Web Server pods


### PR DESCRIPTION
Later implementations of aws alb controller set pathType to a different value >2.3 
https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.3/guide/tasks/ssl_redirect/

```
spec:
  rules:
    - http:
        paths:
         - path: /*
           pathType: ImplementationSpecific
           backend:
             serviceName: user-service
             servicePort: 80
```
