### PR TITLE
Add the ability to disable Serving Statistics and to configure the kafka url

### DIFF
--- a/charts/clearml-serving/Chart.yaml
+++ b/charts/clearml-serving/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clearml-serving
 description: ClearML Serving Helm Chart
 type: application
-version: "1.2.1"
+version: "1.3.0"
 appVersion: "1.3.0"
 kubeVersion: ">= 1.21.0-0 < 1.28.0-0"
 home: https://clear.ml

--- a/charts/clearml-serving/README.md
+++ b/charts/clearml-serving/README.md
@@ -1,6 +1,6 @@
 # ClearML Kubernetes Serving
 
-![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.0](https://img.shields.io/badge/AppVersion-1.3.0-informational?style=flat-square)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.0](https://img.shields.io/badge/AppVersion-1.3.0-informational?style=flat-square)
 
 ClearML Serving Helm Chart
 
@@ -53,7 +53,7 @@ Kubernetes: `>= 1.21.0-0 < 1.28.0-0`
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| clearml | object | `{"apiAccessKey":"ClearML API Access Key","apiHost":"http://clearml-server-apiserver:8008","apiSecretKey":"ClearML API Secret Key","defaultBaseServeUrl":"http://127.0.0.1:8080/serve","filesHost":"http://clearml-server-fileserver:8081","servingTaskId":"ClearML Serving Task ID","webHost":"http://clearml-server-webserver:80"}` | ClearMl generic configurations |
+| clearml | object | `{"apiAccessKey":"ClearML API Access Key","apiHost":"http://clearml-server-apiserver:8008","apiSecretKey":"ClearML API Secret Key","defaultBaseServeUrl":"http://127.0.0.1:8080/serve","filesHost":"http://clearml-server-fileserver:8081","kafkaServeUrl":"","servingTaskId":"ClearML Serving Task ID","webHost":"http://clearml-server-webserver:80"}` | ClearMl generic configurations |
 | clearml_serving_inference | object | `{"affinity":{},"autoscaling":{"enabled":false,"maxReplicas":11,"minReplicas":1,"targetCPU":50,"targetMemory":50},"extraEnvironment":[],"extraPythonPackages":[],"image":{"repository":"allegroai/clearml-serving-inference","tag":"1.3.0"},"ingress":{"annotations":{},"enabled":false,"hostName":"serving.clearml.127-0-0-1.nip.io","ingressClassName":"","path":"/","tlsSecretName":""},"nodeSelector":{},"resources":{},"tolerations":[]}` | ClearML serving inference configurations |
 | clearml_serving_inference.affinity | object | `{}` | Affinity configuration |
 | clearml_serving_inference.autoscaling | object | `{"enabled":false,"maxReplicas":11,"minReplicas":1,"targetCPU":50,"targetMemory":50}` | Autoscaling configuration |
@@ -70,8 +70,9 @@ Kubernetes: `>= 1.21.0-0 < 1.28.0-0`
 | clearml_serving_inference.nodeSelector | object | `{}` | Node Selector configuration |
 | clearml_serving_inference.resources | object | `{}` | Pod resources definition |
 | clearml_serving_inference.tolerations | list | `[]` | Tolerations configuration |
-| clearml_serving_statistics | object | `{"affinity":{},"extraPythonPackages":[],"image":{"repository":"allegroai/clearml-serving-statistics","tag":"1.3.0"},"nodeSelector":{},"resources":{},"tolerations":[]}` | ClearML serving statistics configurations |
+| clearml_serving_statistics | object | `{"affinity":{},"enabled":true,"extraPythonPackages":[],"image":{"repository":"allegroai/clearml-serving-statistics","tag":"1.3.0"},"nodeSelector":{},"resources":{},"tolerations":[]}` | ClearML serving statistics configurations |
 | clearml_serving_statistics.affinity | object | `{}` | Affinity configuration |
+| clearml_serving_statistics.enabled | bool | `true` | Enable ClearML Serving Statistics |
 | clearml_serving_statistics.extraPythonPackages | list | `[]` | Extra Python Packages to be installed in running pods |
 | clearml_serving_statistics.image | object | `{"repository":"allegroai/clearml-serving-statistics","tag":"1.3.0"}` | Container Image |
 | clearml_serving_statistics.nodeSelector | object | `{}` | Node Selector configuration |

--- a/charts/clearml-serving/templates/clearml-serving-inference-deployment.yaml
+++ b/charts/clearml-serving/templates/clearml-serving-inference-deployment.yaml
@@ -30,8 +30,14 @@ spec:
               value: "{{ .Values.clearml.filesHost }}"
             - name: CLEARML_WEB_HOST
               value: "{{ .Values.clearml.webHost }}"
+            {{- if .Values.clearml_serving_statistics.enabled }}
             - name: CLEARML_DEFAULT_KAFKA_SERVE_URL
+              {{- if .Values.clearml.kafkaServeUrl }}
+              value: {{ .Values.clearml.kafkaServeUrl }}
+              {{- else }}
               value: {{ include "clearmlServing.fullname" . }}-kafka:9092
+              {{- end }}
+            {{- end }}
             - name: CLEARML_SERVING_POLL_FREQ
               value: "1.0"
             - name: CLEARML_DEFAULT_BASE_SERVE_URL

--- a/charts/clearml-serving/templates/clearml-serving-statistics-deployment.yaml
+++ b/charts/clearml-serving/templates/clearml-serving-statistics-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.clearml_serving_statistics.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -31,7 +32,11 @@ spec:
             - name: CLEARML_WEB_HOST
               value: "{{ .Values.clearml.webHost }}"
             - name: CLEARML_DEFAULT_KAFKA_SERVE_URL
+              {{- if .Values.clearml.kafkaServeUrl }}
+              value: {{ .Values.clearml.kafkaServeUrl }}
+              {{- else }}
               value: {{ include "clearmlServing.fullname" . }}-kafka:9092
+              {{- end }}
             - name: CLEARML_SERVING_POLL_FREQ
               value: "1.0"
             - name: CLEARML_SERVING_TASK_ID
@@ -47,3 +52,4 @@ spec:
           resources:
             {{- toYaml .Values.clearml_serving_statistics.resources | nindent 12 }}
       restartPolicy: Always
+{{- end }}

--- a/charts/clearml-serving/templates/clearml-serving-statistics-service.yaml
+++ b/charts/clearml-serving/templates/clearml-serving-statistics-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.clearml_serving_statistics.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -12,3 +13,4 @@ spec:
       targetPort: 9999
   selector:
     clearml.serving.service: {{ include "clearmlServing.fullname" . }}-statistics
+{{- end }}

--- a/charts/clearml-serving/values.yaml
+++ b/charts/clearml-serving/values.yaml
@@ -7,9 +7,12 @@ clearml:
   webHost: http://clearml-server-webserver:80
   defaultBaseServeUrl: http://127.0.0.1:8080/serve
   servingTaskId: "ClearML Serving Task ID"
+  kafkaServeUrl: ""
 
 # -- ClearML serving statistics configurations
 clearml_serving_statistics:
+  # -- Enable ClearML Serving Statistics
+  enabled: true
   # -- Container Image
   image:
     repository: "allegroai/clearml-serving-statistics"


### PR DESCRIPTION
**What this PR does / why we need it**:
This MR makes Statisitcs more configurable by being able to disable it and by being able to choose your own Kafka instance.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/allegroai/clearml-helm-charts/blob/main/CONTRIBUTING.md#pull-requests) guide (**required**)
- [x] Verify the work you plan to merge addresses an existing [issue](https://github.com/allegroai/clearml-helm-charts/issues) (If not, open a new one) (**required**)
- [x] Check your branch with `helm lint` (**required**)
- [x] Update `version` in `Chart.yaml` according [semver](https://semver.org/) rules (**required**)
- [x] Substitute `annotations` section in `Chart.yaml` annotating implementations (useful for Artifecthub changelog) (**required**)
- [x] Update chart README using [helm-docs](https://github.com/norwoodj/helm-docs) (**required**)


**Which issue(s) this PR fixes**:

Fixes #238
