### PR TITLE
254 clearml server helper function wrong readiness probes fail because wrong redis service is referenced

### DIFF
--- a/charts/clearml/Chart.yaml
+++ b/charts/clearml/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clearml
 description: MLOps platform
 type: application
-version: "7.4.0"
+version: "7.4.1"
 appVersion: "1.12.0"
 kubeVersion: ">= 1.21.0-0 < 1.29.0-0"
 home: https://clear.ml
@@ -32,5 +32,5 @@ dependencies:
     condition: elasticsearch.enabled
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: service accounts for core clearml components
+    - kind: fixed
+      description: redis service name reference generation

--- a/charts/clearml/README.md
+++ b/charts/clearml/README.md
@@ -1,6 +1,6 @@
 # ClearML Ecosystem for Kubernetes
 
-![Version: 7.4.0](https://img.shields.io/badge/Version-7.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.12.0](https://img.shields.io/badge/AppVersion-1.12.0-informational?style=flat-square)
+![Version: 7.4.1](https://img.shields.io/badge/Version-7.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.12.0](https://img.shields.io/badge/AppVersion-1.12.0-informational?style=flat-square)
 
 MLOps platform
 

--- a/charts/clearml/templates/_helpers.tpl
+++ b/charts/clearml/templates/_helpers.tpl
@@ -216,11 +216,7 @@ Redis Service name
 */}}
 {{- define "redis.servicename" -}}
 {{- if .Values.redis.enabled }}
-{{- if eq .Values.redis.architecture "standalone" }}
 {{- tpl .Values.redis.master.name . }}
-{{- else }}
-{{- printf "%s-headless" (tpl .Values.redis.master.name . ) }}
-{{- end }}
 {{- else }}
 {{- .Values.externalServices.redisHost }}
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes redis svc name refeeence generation when not using standalone mode.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/allegroai/clearml-helm-charts/blob/main/CONTRIBUTING.md#pull-requests) guide (**required**)
- [x] Verify the work you plan to merge addresses an existing [issue](https://github.com/allegroai/clearml-helm-charts/issues) (If not, open a new one) (**required**)
- [x] Check your branch with `helm lint` (**required**)
- [x] Update `version` in `Chart.yaml` according [semver](https://semver.org/) rules (**required**)
- [x] Substitute `annotations` section in `Chart.yaml` annotating implementations (useful for Artifecthub changelog) (**required**)
- [x] Update chart README using [helm-docs](https://github.com/norwoodj/helm-docs) (**required**)


**Which issue(s) this PR fixes**:

Fixes #254 

**Special notes for your reviewer**:

None