### PR TITLE
262 clearml agent wrong nindent for agentk8sglue deployment template

### DIFF
--- a/charts/clearml-agent/Chart.yaml
+++ b/charts/clearml-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clearml-agent
 description: MLOps platform Task running agent
 type: application
-version: "5.1.1"
+version: "5.1.2"
 appVersion: "1.24"
 kubeVersion: ">= 1.21.0-0 < 1.29.0-0"
 home: https://clear.ml
@@ -20,5 +20,5 @@ keywords:
   - "task agent"
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: kubernetes 1.28 support
+    - kind: fixed
+      description: wrong indentation on volumeMounts

--- a/charts/clearml-agent/README.md
+++ b/charts/clearml-agent/README.md
@@ -1,6 +1,6 @@
 # ClearML Kubernetes Agent
 
-![Version: 5.1.1](https://img.shields.io/badge/Version-5.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.24](https://img.shields.io/badge/AppVersion-1.24-informational?style=flat-square)
+![Version: 5.1.2](https://img.shields.io/badge/Version-5.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.24](https://img.shields.io/badge/AppVersion-1.24-informational?style=flat-square)
 
 MLOps platform Task running agent
 

--- a/charts/clearml-agent/templates/agentk8sglue-deployment.yaml
+++ b/charts/clearml-agent/templates/agentk8sglue-deployment.yaml
@@ -74,7 +74,7 @@ spec:
               readOnly: true
             {{- end }}
             {{- if .Values.agentk8sglue.volumeMounts }}
-            {{- toYaml .Values.agentk8sglue.volumeMounts | nindent 10 }}
+            {{- toYaml .Values.agentk8sglue.volumeMounts | nindent 12 }}
             {{- end }}
             {{- range .Values.agentk8sglue.fileMounts }}
             - name: filemounts


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix wrong indentation.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/allegroai/clearml-helm-charts/blob/main/CONTRIBUTING.md#pull-requests) guide (**required**)
- [x] Verify the work you plan to merge addresses an existing [issue](https://github.com/allegroai/clearml-helm-charts/issues) (If not, open a new one) (**required**)
- [x] Check your branch with `helm lint` (**required**)
- [x] Update `version` in `Chart.yaml` according [semver](https://semver.org/) rules (**required**)
- [x] Substitute `annotations` section in `Chart.yaml` annotating implementations (useful for Artifecthub changelog) (**required**)
- [x] Update chart README using [helm-docs](https://github.com/norwoodj/helm-docs) (**required**)


**Which issue(s) this PR fixes**:

Fixes #262 


