### PR TITLE
277 apiserver and asyncdelete apiserver having the same selector

### DIFF
--- a/charts/clearml/Chart.yaml
+++ b/charts/clearml/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clearml
 description: MLOps platform
 type: application
-version: "7.8.1"
+version: "7.8.2"
 appVersion: "1.15"
 kubeVersion: ">= 1.21.0-0 < 1.30.0-0"
 home: https://clear.ml
@@ -33,4 +33,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: missing async delete config mount
+      description: asyncdelete wrong selector

--- a/charts/clearml/README.md
+++ b/charts/clearml/README.md
@@ -1,6 +1,6 @@
 # ClearML Ecosystem for Kubernetes
 
-![Version: 7.8.1](https://img.shields.io/badge/Version-7.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.15](https://img.shields.io/badge/AppVersion-1.15-informational?style=flat-square)
+![Version: 7.8.2](https://img.shields.io/badge/Version-7.8.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.15](https://img.shields.io/badge/AppVersion-1.15-informational?style=flat-square)
 
 MLOps platform
 

--- a/charts/clearml/templates/apiserver-asyncdelete-deployment.yaml
+++ b/charts/clearml/templates/apiserver-asyncdelete-deployment.yaml
@@ -10,7 +10,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "apiserver.selectorLabels" . | nindent 6 }}
+      {{- include "clearml.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       {{- with .Values.apiserver.podAnnotations }}
@@ -18,7 +18,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "apiserver.selectorLabels" . | nindent 8 }}
+        {{- include "clearml.selectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ .Values.apiserver.serviceAccountName }}-apiserver
       {{- if .Values.imageCredentials.enabled }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Asyncdelete wrong selector 

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/allegroai/clearml-helm-charts/blob/main/CONTRIBUTING.md#pull-requests) guide (**required**)
- [x] Verify the work you plan to merge addresses an existing [issue](https://github.com/allegroai/clearml-helm-charts/issues) (If not, open a new one) (**required**)
- [x] Check your branch with `helm lint` (**required**)
- [x] Update `version` in `Chart.yaml` according [semver](https://semver.org/) rules (**required**)
- [x] Substitute `annotations` section in `Chart.yaml` annotating implementations (useful for Artifecthub changelog) (**required**)
- [x] Update chart README using [helm-docs](https://github.com/norwoodj/helm-docs) (**required**)


**Which issue(s) this PR fixes**:

Fixes #277 
