### PR TITLE
affinity for serving deployments was incorrectly put under containers…

### DIFF
--- a/charts/clearml-serving/Chart.yaml
+++ b/charts/clearml-serving/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clearml-serving
 description: ClearML Serving Helm Chart
 type: application
-version: "1.5.4"
+version: "1.5.5"
 appVersion: "1.3.0"
 kubeVersion: ">= 1.21.0-0 < 1.30.0-0"
 home: https://clear.ml
@@ -34,4 +34,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: kubernetes 1.29 support
+      description: fixed affinity in serving templates. They need to be set on the pod and not the container.

--- a/charts/clearml-serving/README.md
+++ b/charts/clearml-serving/README.md
@@ -1,6 +1,6 @@
 # ClearML Kubernetes Serving
 
-![Version: 1.5.5](https://img.shields.io/badge/Version-1.5.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.0](https://img.shields.io/badge/AppVersion-1.3.0-informational?style=flat-square) 
+![Version: 1.5.5](https://img.shields.io/badge/Version-1.5.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.0](https://img.shields.io/badge/AppVersion-1.3.0-informational?style=flat-square)
 
 ClearML Serving Helm Chart
 

--- a/charts/clearml-serving/README.md
+++ b/charts/clearml-serving/README.md
@@ -1,6 +1,7 @@
 # ClearML Kubernetes Serving
 
-![Version: 1.5.4](https://img.shields.io/badge/Version-1.5.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.0](https://img.shields.io/badge/AppVersion-1.3.0-informational?style=flat-square)
+
+![Version: 1.5.5](https://img.shields.io/badge/Version-1.5.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.0](https://img.shields.io/badge/AppVersion-1.3.0-informational?style=flat-square) 
 
 ClearML Serving Helm Chart
 

--- a/charts/clearml-serving/README.md
+++ b/charts/clearml-serving/README.md
@@ -1,6 +1,5 @@
 # ClearML Kubernetes Serving
 
-
 ![Version: 1.5.5](https://img.shields.io/badge/Version-1.5.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.0](https://img.shields.io/badge/AppVersion-1.3.0-informational?style=flat-square) 
 
 ClearML Serving Helm Chart

--- a/charts/clearml-serving/templates/clearml-serving-inference-deployment.yaml
+++ b/charts/clearml-serving/templates/clearml-serving-inference-deployment.yaml
@@ -40,6 +40,10 @@ spec:
             name: "{{ include "clearmlServing.fullname" . }}-inference-configmap"
           {{- end }}
       {{- end }}
+      {{- with .Values.clearml_serving_inference.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - env:
             - name: CLEARML_API_ACCESS_KEY
@@ -96,10 +100,6 @@ spec:
           {{- end }}
           {{- with .Values.clearml_serving_inference.nodeSelector }}
           nodeSelector:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .Values.clearml_serving_inference.affinity }}
-          affinity:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.clearml_serving_inference.tolerations }}

--- a/charts/clearml-serving/templates/clearml-serving-statistics-deployment.yaml
+++ b/charts/clearml-serving/templates/clearml-serving-statistics-deployment.yaml
@@ -41,6 +41,10 @@ spec:
             name: "{{ include "clearmlServing.fullname" . }}-statistics-configmap"
           {{- end }}
       {{- end }}
+      {{- with .Values.clearml_serving_statistics.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - env:
             - name: CLEARML_API_ACCESS_KEY
@@ -81,10 +85,6 @@ spec:
           {{- end }}
           {{- with .Values.clearml_serving_statistics.nodeSelector }}
           nodeSelector:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .Values.clearml_serving_statistics.affinity }}
-          affinity:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.clearml_serving_statistics.tolerations }}

--- a/charts/clearml-serving/templates/clearml-serving-triton-deployment.yaml
+++ b/charts/clearml-serving/templates/clearml-serving-triton-deployment.yaml
@@ -44,6 +44,10 @@ spec:
             name: "{{ include "clearmlServing.fullname" . }}-triton-configmap"
           {{- end }}
       {{- end }}
+      {{- with .Values.clearml_serving_triton.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - env:
             - name: CLEARML_API_ACCESS_KEY
@@ -77,11 +81,6 @@ spec:
           volumeMounts:  
             - name: additional-config
               mountPath: /opt/clearml/config
-          {{- end }}
-          
-          {{- with .Values.clearml_serving_triton.affinity }}
-          affinity:
-            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.clearml_serving_triton.tolerations }}
           tolerations:


### PR DESCRIPTION
…. It needs to be put at pod spec level.

**What this PR does / why we need it**:


**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/allegroai/clearml-helm-charts/blob/main/CONTRIBUTING.md#pull-requests) guide (**required**)
- [x] Verify the work you plan to merge addresses an existing [issue](https://github.com/allegroai/clearml-helm-charts/issues) (If not, open a new one) (**required**)
- [x] Check your branch with `helm lint` (**required**)
- [x] Update `version` in `Chart.yaml` according [semver](https://semver.org/) rules (**required**)
- [x] Substitute `annotations` section in `Chart.yaml` annotating implementations (useful for Artifecthub changelog) (**required**)
- [x] Update chart README using [helm-docs](https://github.com/norwoodj/helm-docs) (**required**)


**Which issue(s) this PR fixes**:

affinity for serving deployments was incorrectly put under containers. It needs to be put at pod spec level.

**Special notes for your reviewer**:

