### PR TITLE
Use existingClearmlConfigSecret

### DIFF
--- a/charts/clearml-agent/Chart.yaml
+++ b/charts/clearml-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clearml-agent
 description: MLOps platform Task running agent
 type: application
-version: "5.1.4"
+version: "5.1.5"
 appVersion: "1.24"
 kubeVersion: ">= 1.21.0-0 < 1.30.0-0"
 home: https://clear.ml
@@ -21,4 +21,4 @@ keywords:
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: honor existingAgentk8sglueSecret in deployment template
+      description: Use existingClearmlConfigSecret in deployment template

--- a/charts/clearml-agent/README.md
+++ b/charts/clearml-agent/README.md
@@ -1,6 +1,6 @@
 # ClearML Kubernetes Agent
 
-![Version: 5.1.4](https://img.shields.io/badge/Version-5.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.24](https://img.shields.io/badge/AppVersion-1.24-informational?style=flat-square)
+![Version: 5.1.5](https://img.shields.io/badge/Version-5.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.24](https://img.shields.io/badge/AppVersion-1.24-informational?style=flat-square)
 
 MLOps platform Task running agent
 

--- a/charts/clearml-agent/templates/agentk8sglue-deployment.yaml
+++ b/charts/clearml-agent/templates/agentk8sglue-deployment.yaml
@@ -67,7 +67,7 @@ spec:
           volumeMounts:
             - name: {{ include "clearmlAgent.fullname" . }}-pt
               mountPath: /root/template
-            {{ if .Values.clearml.clearmlConfig }}
+            {{ if or (.Values.clearml.clearmlConfig) (.Values.clearml.existingClearmlConfigSecret) }}
             - name: k8sagent-clearml-conf-volume
               mountPath: /root/clearml.conf
               subPath: clearml.conf
@@ -103,7 +103,7 @@ spec:
             - name: K8S_GLUE_EXTRA_ARGS
               value: "--namespace {{ .Release.Namespace }} --template-yaml /root/template/template.yaml"
             {{- end }}
-            {{- if .Values.clearml.clearmlConfig }}
+            {{ if or (.Values.clearml.clearmlConfig) (.Values.clearml.existingClearmlConfigSecret) }}
             - name: CLEARML_CONFIG_FILE
               value: /root/clearml.conf
             {{- end }}
@@ -160,7 +160,14 @@ spec:
         - name: {{ include "clearmlAgent.fullname" . }}-pt
           configMap:
             name: {{ include "clearmlAgent.fullname" . }}-pt
-        {{ if .Values.clearml.clearmlConfig }}
+        {{ if .Values.clearml.existingClearmlConfigSecret }}
+        - name: k8sagent-clearml-conf-volume
+          secret:
+            secretName: {{ .Values.clearml.existingClearmlConfigSecret }}
+            items:
+            - key: clearml.conf
+              path: clearml.conf
+        {{ else if .Values.clearml.clearmlConfig }}
         - name: k8sagent-clearml-conf-volume
           secret:
             secretName: {{ include "clearmlAgent.fullname" . }}-ac

--- a/charts/clearml-agent/templates/clearml-secrets.yaml
+++ b/charts/clearml-agent/templates/clearml-secrets.yaml
@@ -1,3 +1,4 @@
+{{- if or (not .Values.clearml.existingAgentk8sglueSecret) (not .Values.clearml.existingClearmlConfigSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,6 +7,7 @@ data:
   agentk8sglue_key: {{ .Values.clearml.agentk8sglueKey | b64enc }}
   agentk8sglue_secret: {{ .Values.clearml.agentk8sglueSecret | b64enc }}
   clearml.conf: {{ .Values.clearml.clearmlConfig | b64enc }}
+{{- end }}
 ---
 {{- if .Values.imageCredentials.enabled }}
 {{- if not .Values.imageCredentials.existingSecret }}

--- a/charts/clearml-agent/values.yaml
+++ b/charts/clearml-agent/values.yaml
@@ -28,6 +28,16 @@ clearml:
   agentk8sglueSecret: "SECRETKEY"
 
   # -- If this is set, chart will not generate a secret but will use what is defined here
+  # The secret should be defined as the following example
+  #
+  # apiVersion: v1
+  # kind: Secret
+  # metadata:
+  #   name: secret-name
+  # stringData:
+  #   clearml.conf: |-
+  #     sdk {
+  #     }
   existingClearmlConfigSecret: ""
   # -- ClearML configuration file
   clearmlConfig: |-

--- a/charts/clearml-agent/values.yaml
+++ b/charts/clearml-agent/values.yaml
@@ -28,6 +28,7 @@ clearml:
   agentk8sglueSecret: "SECRETKEY"
 
   # -- If this is set, chart will not generate a secret but will use what is defined here
+  existingClearmlConfigSecret: ""
   # The secret should be defined as the following example
   #
   # apiVersion: v1
@@ -38,7 +39,6 @@ clearml:
   #   clearml.conf: |-
   #     sdk {
   #     }
-  existingClearmlConfigSecret: ""
   # -- ClearML configuration file
   clearmlConfig: |-
     sdk {


### PR DESCRIPTION
**What this PR does / why we need it**:
The deployment template for the agentk8sglue in the clearml-agent chart is not using the existingClearmlConfigSecret if it's set.

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/allegroai/clearml-helm-charts/blob/main/CONTRIBUTING.md#pull-requests) guide (**required**)
- [x] Verify the work you plan to merge addresses an existing [issue](https://github.com/allegroai/clearml-helm-charts/issues) (If not, open a new one) (**required**)
- [x] Check your branch with `helm lint` (**required**)
- [x] Update `version` in `Chart.yaml` according [semver](https://semver.org/) rules (**required**)
- [x] Substitute `annotations` section in `Chart.yaml` annotating implementations (useful for Artifecthub changelog) (**required**)
- [x] Update chart README using [helm-docs](https://github.com/norwoodj/helm-docs) (**required**)


**Which issue(s) this PR fixes**:

Fixes #282

**Special notes for your reviewer**:

