### PR TITLE
Secrets and keys for ClearML generic configurations can be generated randomly

### DIFF
--- a/charts/clearml/Chart.yaml
+++ b/charts/clearml/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clearml
 description: MLOps platform
 type: application
-version: "7.11.0"
+version: "7.11.1"
 appVersion: "1.16"
 kubeVersion: ">= 1.21.0-0 < 1.31.0-0"
 home: https://clear.ml

--- a/charts/clearml/Chart.yaml
+++ b/charts/clearml/Chart.yaml
@@ -32,7 +32,5 @@ dependencies:
     condition: elasticsearch.enabled
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: app version 1.16
-    - kind: fixed
-      description: missing env vars in async
+    - kind: added
+      description: Ability to generate secrets and keys for ClearML generic configurations randomly

--- a/charts/clearml/templates/_helpers.tpl
+++ b/charts/clearml/templates/_helpers.tpl
@@ -150,7 +150,7 @@ Create secret to access docker registry
 Create readiness probe auth token
 */}}
 {{- define "readinessProbeAuth" }}
-{{- printf "%s:%s" .Values.clearml.readinessprobeKey .Values.clearml.readinessprobeSecret | b64enc }}
+{{- printf "%s:%s" (default (randAlpha 20 | upper) .Values.clearml.readinessprobeKey) (default (randAlpha 20 | upper) .Values.clearml.readinessprobeSecret) | b64enc }}
 {{- end }}
 
 {{/*

--- a/charts/clearml/templates/clearml-secrets.yaml
+++ b/charts/clearml/templates/clearml-secrets.yaml
@@ -3,13 +3,13 @@ kind: Secret
 metadata:
   name: clearml-conf
 data:
-  apiserver_key: {{ .Values.clearml.apiserverKey | b64enc }}
-  apiserver_secret: {{ .Values.clearml.apiserverSecret | b64enc }}
-  fileserver_key: {{ .Values.clearml.fileserverKey | b64enc }}
-  fileserver_secret: {{ .Values.clearml.fileserverSecret | b64enc }}
-  secure_auth_token_secret: {{ .Values.clearml.secureAuthTokenSecret | b64enc }}
-  test_user_key: {{ .Values.clearml.testUserKey | b64enc }}
-  test_user_secret: {{ .Values.clearml.testUserSecret | b64enc }}
+  apiserver_key: {{ default (randAlpha 20 | upper) .Values.clearml.apiserverKey | b64enc }}
+  apiserver_secret: {{ default (randAlpha 50 | upper) .Values.clearml.apiserverSecret | b64enc }}
+  fileserver_key: {{ default (randAlpha 20 | upper) .Values.clearml.fileserverKey | b64enc }}
+  fileserver_secret: {{ default (randAlpha 50 | upper) .Values.clearml.fileserverSecret | b64enc }}
+  secure_auth_token_secret: {{ default (randAlpha 50 | upper) .Values.clearml.secureAuthTokenSecret | b64enc }}
+  test_user_key: {{ default (randAlpha 20 | upper) .Values.clearml.testUserKey | b64enc }}
+  test_user_secret: {{ default (randAlpha 50 | upper) .Values.clearml.testUserSecret | b64enc }}
 ---
 {{- if .Values.imageCredentials.enabled }}
 {{- if not .Values.imageCredentials.existingSecret }}

--- a/charts/clearml/values.yaml
+++ b/charts/clearml/values.yaml
@@ -26,28 +26,31 @@ clearml:
   cookieDomain: ""
   # -- Company name
   defaultCompany: "d1bd92a3b039400cbafc60a7a5b1e52b"
-  # -- Api Server basic auth key
-  apiserverKey: GGS9F4M6XB2DXJ5AFT9F
-  # -- Api Server basic auth secret
-  apiserverSecret: 2oGujVFhPfaozhpuz2GzQfA5OyxmMsR3WVJpsCR5hrgHFs20PO
-  # -- File Server basic auth key
-  fileserverKey: XXCRJ123CEE2KSQ068WO
-  # -- File Server basic auth secret
-  fileserverSecret: YIy8EVAC7QCT4FtgitxAQGyW7xRHDZ4jpYlTE7HKiscpORl1hG
   # -- Readiness probe basic auth key
   readinessprobeKey: GK4PRTVT3706T25K6BA1
   # -- Readiness probe basic auth secret
   readinessprobeSecret: ymLh1ok5k5xNUQfS944Xdx9xjf0wueokqKM2dMZfHuH9ayItG2
-  # -- Secure Auth secret
-  secureAuthTokenSecret: ymLh1ok5k5xNUQfS944Xdx9xjf0wueokqKM2dMZfHuH9ayItG2
-  # -- Test Server basic auth key
-  testUserKey: "ENP39EQM4SLACGD5FXB7"
-  # -- Test File Server basic auth secret
-  testUserSecret: "lPcm0imbcBZ8mwgO7tpadutiS3gnJD05x9j7afwXPS35IKbpiQ"
   # -- Override the API Urls displayed when showing an example of the SDK's clearml.conf configuration
   clientConfigurationApiUrl: ""
   # -- Override the Files Urls displayed when showing an example of the SDK's clearml.conf configuration
   clientConfigurationFilesUrl: ""
+
+  # -- The following secrets are optional. If left uncommented or empty, they will be generated randomly.
+  # -- Api Server basic auth key
+  # apiserverKey: GGS9F4M6XB2DXJ5AFT9F
+  # -- Api Server basic auth secret
+  # apiserverSecret: 2oGujVFhPfaozhpuz2GzQfA5OyxmMsR3WVJpsCR5hrgHFs20PO
+  # -- File Server basic auth key
+  # fileserverKey: XXCRJ123CEE2KSQ068WO
+  # -- File Server basic auth secret
+  # fileserverSecret: YIy8EVAC7QCT4FtgitxAQGyW7xRHDZ4jpYlTE7HKiscpORl1hG
+  # -- Secure Auth secret
+  # secureAuthTokenSecret: ymLh1ok5k5xNUQfS944Xdx9xjf0wueokqKM2dMZfHuH9ayItG2
+  # -- Test Server basic auth key
+  # testUserKey: "ENP39EQM4SLACGD5FXB7"
+  # -- Test File Server basic auth secret
+  # testUserSecret: "lPcm0imbcBZ8mwgO7tpadutiS3gnJD05x9j7afwXPS35IKbpiQ"
+
   # -- Pass Clearml secrets using an existing secret
   # must contain the keys: apiserver_key, apiserver_secret, secure_auth_token_secret, test_user_key, test_user_secret
   existingSecret: ""

--- a/charts/clearml/values.yaml
+++ b/charts/clearml/values.yaml
@@ -26,10 +26,6 @@ clearml:
   cookieDomain: ""
   # -- Company name
   defaultCompany: "d1bd92a3b039400cbafc60a7a5b1e52b"
-  # -- Readiness probe basic auth key
-  readinessprobeKey: GK4PRTVT3706T25K6BA1
-  # -- Readiness probe basic auth secret
-  readinessprobeSecret: ymLh1ok5k5xNUQfS944Xdx9xjf0wueokqKM2dMZfHuH9ayItG2
   # -- Override the API Urls displayed when showing an example of the SDK's clearml.conf configuration
   clientConfigurationApiUrl: ""
   # -- Override the Files Urls displayed when showing an example of the SDK's clearml.conf configuration
@@ -50,6 +46,10 @@ clearml:
   # testUserKey: "ENP39EQM4SLACGD5FXB7"
   # -- Test File Server basic auth secret
   # testUserSecret: "lPcm0imbcBZ8mwgO7tpadutiS3gnJD05x9j7afwXPS35IKbpiQ"
+  # -- Readiness probe basic auth key
+  # readinessprobeKey: GK4PRTVT3706T25K6BA1
+  # -- Readiness probe basic auth secret
+  # readinessprobeSecret: ymLh1ok5k5xNUQfS944Xdx9xjf0wueokqKM2dMZfHuH9ayItG2
 
   # -- Pass Clearml secrets using an existing secret
   # must contain the keys: apiserver_key, apiserver_secret, secure_auth_token_secret, test_user_key, test_user_secret


### PR DESCRIPTION
**What this PR does / why we need it**:


**Checklist**
- [v] Reviewed the [`CONTRIBUTING.md`](https://github.com/allegroai/clearml-helm-charts/blob/main/CONTRIBUTING.md#pull-requests) guide (**required**)
- [v] Verify the work you plan to merge addresses an existing [issue](https://github.com/allegroai/clearml-helm-charts/issues) (If not, open a new one) (**required**)
- [v] Check your branch with `helm lint` (**required**)
- [v] Update `version` in `Chart.yaml` according [semver](https://semver.org/) rules (**required**)
- [v] Substitute `annotations` section in `Chart.yaml` annotating implementations (useful for Artifecthub changelog) (**required**)
- [v] Update chart README using [helm-docs](https://github.com/norwoodj/helm-docs) (**required**)


**Which issue(s) this PR fixes**:

Fixes #305

**Special notes for your reviewer**:
This allow users to deploy the helmchart without specifying (hard-code) the keys & secrets. 
We are running it in our on-prem k8s, it is working.
