### PR TITLE
Fix duplicate `CLEARML__secure__auth__token_secret` in `apiserver-asyncdelete-deployment.yaml`

### DIFF
--- a/charts/clearml/Chart.yaml
+++ b/charts/clearml/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clearml
 description: MLOps platform
 type: application
-version: "7.11.3"
+version: "7.11.4"
 appVersion: "1.16"
 kubeVersion: ">= 1.21.0-0 < 1.31.0-0"
 home: https://clear.ml

--- a/charts/clearml/Chart.yaml
+++ b/charts/clearml/Chart.yaml
@@ -32,5 +32,5 @@ dependencies:
     condition: elasticsearch.enabled
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: Updated version to 1.16.2
+    - kind: fixed
+      description: Removed duplicated env

--- a/charts/clearml/README.md
+++ b/charts/clearml/README.md
@@ -1,6 +1,6 @@
 # ClearML Ecosystem for Kubernetes
 
-![Version: 7.11.3](https://img.shields.io/badge/Version-7.11.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16](https://img.shields.io/badge/AppVersion-1.16-informational?style=flat-square)
+![Version: 7.11.4](https://img.shields.io/badge/Version-7.11.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16](https://img.shields.io/badge/AppVersion-1.16-informational?style=flat-square)
 
 MLOps platform
 

--- a/charts/clearml/templates/apiserver-asyncdelete-deployment.yaml
+++ b/charts/clearml/templates/apiserver-asyncdelete-deployment.yaml
@@ -121,11 +121,6 @@ spec:
             value: "{{ .Values.clearml.defaultCompanyGuid }}"
           - name: CLEARML__services__async_urls_delete__fileserver__url_prefixes
             value: "[\"{{ include "clearml.fileUrl" . }}\"]"
-          - name: CLEARML__secure__auth__token_secret
-            valueFrom:
-              secretKeyRef:
-                name: {{ include "clearml.confSecretName" .}}
-                key: secure_auth_token_secret
           {{- if or .Values.apiserver.additionalConfigs .Values.apiserver.existingAdditionalConfigsConfigMap  .Values.apiserver.existingAdditionalConfigsSecret }}
           volumeMounts:  
             - name: apiserver-config


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes duplicate environment variable

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/allegroai/clearml-helm-charts/blob/main/CONTRIBUTING.md#pull-requests) guide (**required**)
- [x] Verify the work you plan to merge addresses an existing [issue](https://github.com/allegroai/clearml-helm-charts/issues) (If not, open a new one) (**required**)
- [x] Check your branch with `helm lint` (**required**)
- [x] Update `version` in `Chart.yaml` according [semver](https://semver.org/) rules (**required**)
- [x] Substitute `annotations` section in `Chart.yaml` annotating implementations (useful for Artifecthub changelog) (**required**)
- [x] Update chart README using [helm-docs](https://github.com/norwoodj/helm-docs) (**required**)


**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Special notes for your reviewer**:

