### PR TITLE
Add missing schedulerName definition

### DIFF
--- a/charts/clearml-agent/templates/agentk8sglue-configmap.yaml
+++ b/charts/clearml-agent/templates/agentk8sglue-configmap.yaml
@@ -27,6 +27,9 @@ data:
       serviceAccountName: {{ include "clearmlAgent.serviceAccountName" $ }}
       securityContext:
         {{ toYaml .Values.agentk8sglue.basePodTemplate.podSecurityContext | nindent 8 }}
+      {{- if .Values.agentk8sglue.basePodTemplate.schedulerName }}
+      schedulerName: {{ .Values.agentk8sglue.basePodTemplate.schedulerName }}
+      {{- end }}
       priorityClassName: {{ .Values.agentk8sglue.basePodTemplate.priorityClassName }}
       initContainers:
         {{- toYaml .Values.agentk8sglue.basePodTemplate.initContainers | nindent 8 }}


### PR DESCRIPTION
**What this PR does / why we need it**:

when defining in values.yaml:
```
agentk8sglue:
  basePodTemplate:
    schedulerName: different-scheduler
```

the value isn't propagated to the configmap eventually created.

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/allegroai/clearml-helm-charts/blob/main/CONTRIBUTING.md#pull-requests) guide (**required**)
- [ ] Verify the work you plan to merge addresses an existing [issue](https://github.com/allegroai/clearml-helm-charts/issues) (If not, open a new one) (**required**)
- [ ] Check your branch with `helm lint` (**required**)
- [ ] Update `version` in `Chart.yaml` according [semver](https://semver.org/) rules (**required**)
- [ ] Substitute `annotations` section in `Chart.yaml` annotating implementations (useful for Artifecthub changelog) (**required**)
- [ ] Update chart README using [helm-docs](https://github.com/norwoodj/helm-docs) (**required**)


**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Special notes for your reviewer**:

